### PR TITLE
tweaked examples by adding debug statements for better console output

### DIFF
--- a/examples/example-async-client.py
+++ b/examples/example-async-client.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from __future__ import print_function
 
 usage = """Usage:
-python example-service.py &
-python example-async-client.py
-python example-client.py --exit-service
+python3 example-service.py &
+python3 example-async-client.py
+python3 example-client.py --exit-service
 """
 
 # Copyright (C) 2004-2006 Red Hat Inc. <http://www.redhat.com/>
 # Copyright (C) 2005-2007 Collabora Ltd. <http://www.collabora.co.uk/>
+#
+# SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -32,7 +36,7 @@ python example-client.py --exit-service
 import sys
 import traceback
 
-import gobject
+from gi.repository import GLib
 
 import dbus
 import dbus.mainloop.glib
@@ -43,7 +47,7 @@ def handle_hello_reply(r):
     global hello_replied
     hello_replied = True
 
-    print str(r)
+    print("async client:", str(r))
 
     if hello_replied and raise_replied:
         loop.quit()
@@ -54,8 +58,8 @@ def handle_hello_error(e):
     hello_replied = True
     failed = True
 
-    print "HelloWorld raised an exception! That's not meant to happen..."
-    print "\t", str(e)
+    print("async client: HelloWorld raised an exception! That's not meant to happen...")
+    print("\t", str(e))
 
     if hello_replied and raise_replied:
         loop.quit()
@@ -66,7 +70,7 @@ def handle_raise_reply():
     raise_replied = True
     failed = True
 
-    print "RaiseException returned normally! That's not meant to happen..."
+    print("async client: RaiseException returned normally! That's not meant to happen...")
 
     if hello_replied and raise_replied:
         loop.quit()
@@ -75,8 +79,8 @@ def handle_raise_error(e):
     global raise_replied
     raise_replied = True
 
-    print "RaiseException raised an exception as expected:"
-    print "\t", str(e)
+    print("async client: RaiseException raised an exception as expected:")
+    print("\t", str(e))
 
     if hello_replied and raise_replied:
         loop.quit()
@@ -104,17 +108,18 @@ if __name__ == '__main__':
         remote_object = bus.get_object("com.example.SampleService","/SomeObject")
     except dbus.DBusException:
         traceback.print_exc()
-        print usage
+        print(usage)
         sys.exit(1)
 
     # Make the method call after a short delay
-    gobject.timeout_add(1000, make_calls)
+    GLib.timeout_add(1000, make_calls)
+    print("async client: method call timeout began. Continuing other operations...")
 
     failed = False
     hello_replied = False
     raise_replied = False
 
-    loop = gobject.MainLoop()
+    loop = GLib.MainLoop()
     loop.run()
     if failed:
         raise SystemExit("Example async client failed!")

--- a/examples/example-client.py
+++ b/examples/example-client.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from __future__ import print_function
 
 usage = """Usage:
-python example-service.py &
-python example-client.py
-python example-client.py --exit-service
+python3 example-service.py &
+python3 example-client.py
+python3 example-client.py --exit-service
 """
 
 # Copyright (C) 2004-2006 Red Hat Inc. <http://www.redhat.com/>
 # Copyright (C) 2005-2007 Collabora Ltd. <http://www.collabora.co.uk/>
+#
+# SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -46,30 +50,30 @@ def main():
             dbus_interface = "com.example.SampleInterface")
     except dbus.DBusException:
         print_exc()
-        print usage
+        print(usage)
         sys.exit(1)
 
-    print (hello_reply_list)
+    print("client:", hello_reply_list)
 
     # ... or create an Interface wrapper for the remote object
     iface = dbus.Interface(remote_object, "com.example.SampleInterface")
 
     hello_reply_tuple = iface.GetTuple()
 
-    print hello_reply_tuple
+    print("client:", hello_reply_tuple)
 
     hello_reply_dict = iface.GetDict()
 
-    print hello_reply_dict
+    print("client:", hello_reply_dict)
 
     # D-Bus exceptions are mapped to Python exceptions
     try:
         iface.RaiseException()
     except dbus.DBusException as e:
-        print str(e)
+        print("client:", str(e))
 
     # introspection is automatically supported
-    print remote_object.Introspect(dbus_interface="org.freedesktop.DBus.Introspectable")
+    print("client:", remote_object.Introspect(dbus_interface="org.freedesktop.DBus.Introspectable"))
 
     if sys.argv[1:] == ['--exit-service']:
         iface.Exit()

--- a/examples/example-service.py
+++ b/examples/example-service.py
@@ -1,14 +1,18 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from __future__ import print_function
 
 usage = """Usage:
-python example-service.py &
-python example-client.py
-python example-async-client.py
-python example-client.py --exit-service
+python3 example-service.py &
+python3 example-client.py
+python3 example-async-client.py
+python3 example-client.py --exit-service
 """
 
 # Copyright (C) 2004-2006 Red Hat Inc. <http://www.redhat.com/>
 # Copyright (C) 2005-2007 Collabora Ltd. <http://www.collabora.co.uk/>
+#
+# SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -30,7 +34,7 @@ python example-client.py --exit-service
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import gobject
+from gi.repository import GLib
 
 import dbus
 import dbus.service
@@ -44,7 +48,7 @@ class SomeObject(dbus.service.Object):
     @dbus.service.method("com.example.SampleInterface",
                          in_signature='s', out_signature='as')
     def HelloWorld(self, hello_message):
-        print (str(hello_message))
+        print("service:", str(hello_message))
         return ["Hello", " from example-service.py", "with unique name",
                 session_bus.get_unique_name()]
 
@@ -77,7 +81,7 @@ if __name__ == '__main__':
     name = dbus.service.BusName("com.example.SampleService", session_bus)
     object = SomeObject(session_bus, '/SomeObject')
 
-    mainloop = gobject.MainLoop()
-    print "Running example service."
-    print usage
+    mainloop = GLib.MainLoop()
+    print("Running example service.")
+    print(usage)
     mainloop.run()

--- a/examples/example-signal-emitter.py
+++ b/examples/example-signal-emitter.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from __future__ import print_function
 
 usage = """Usage:
-python example-signal-emitter.py &
-python example-signal-recipient.py
-python example-signal-recipient.py --exit-service
+python3 example-signal-emitter.py &
+python3 example-signal-recipient.py
+python3 example-signal-recipient.py --exit-service
 """
 
 # Copyright (C) 2004-2006 Red Hat Inc. <http://www.redhat.com/>
 # Copyright (C) 2005-2007 Collabora Ltd. <http://www.collabora.co.uk/>
+#
+# SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -29,7 +33,7 @@ python example-signal-recipient.py --exit-service
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import gobject
+from gi.repository import GLib
 
 import dbus
 import dbus.service
@@ -48,7 +52,7 @@ class TestObject(dbus.service.Object):
     @dbus.service.method('com.example.TestService')
     def emitHelloSignal(self):
         #you emit signals by calling the signal's skeleton method
-        self.HelloSignal('Hello')
+        self.HelloSignal('HelloWorld')
         return 'Signal emitted'
 
     @dbus.service.method("com.example.TestService",
@@ -63,7 +67,7 @@ if __name__ == '__main__':
     name = dbus.service.BusName('com.example.TestService', session_bus)
     object = TestObject(session_bus)
 
-    loop = gobject.MainLoop()
-    print "Running example signal emitter service."
-    print usage
+    loop = GLib.MainLoop()
+    print("Running example signal emitter service.")
+    print(usage)
     loop.run()

--- a/examples/example-signal-recipient.py
+++ b/examples/example-signal-recipient.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from __future__ import print_function
 
 usage = """Usage:
-python example-signal-emitter.py &
-python example-signal-recipient.py
-python example-signal-recipient.py --exit-service
+python3 example-signal-emitter.py &
+python3 example-signal-recipient.py
+python3 example-signal-recipient.py --exit-service
 """
 
 # Copyright (C) 2004-2006 Red Hat Inc. <http://www.redhat.com/>
 # Copyright (C) 2005-2007 Collabora Ltd. <http://www.collabora.co.uk/>
+#
+# SPDX-License-Identifier: MIT
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -32,23 +36,23 @@ python example-signal-recipient.py --exit-service
 import sys
 import traceback
 
-import gobject
+from gi.repository import GLib
 
 import dbus
 import dbus.mainloop.glib
 
 def handle_reply(msg):
-    print msg
+    print("recipient:", msg)
 
 def handle_error(e):
-    print str(e)
+    print("recipient:", str(e))
 
 def emit_signal():
    #call the emitHelloSignal method 
    object.emitHelloSignal(dbus_interface="com.example.TestService")
                           #reply_handler = handle_reply, error_handler = handle_error)
    # exit after waiting a short time for the signal
-   gobject.timeout_add(2000, loop.quit)
+   GLib.timeout_add(2000, loop.quit)
 
    if sys.argv[1:] == ['--exit-service']:
       object.Exit(dbus_interface='com.example.TestService')
@@ -56,20 +60,20 @@ def emit_signal():
    return False
 
 def hello_signal_handler(hello_string):
-    print ("Received signal (by connecting using remote object) and it says: "
+    print("recipient: Received signal (by connecting using remote object) and it says: "
            + hello_string)
 
 def catchall_signal_handler(*args, **kwargs):
-    print ("Caught signal (in catchall handler) "
-           + kwargs['dbus_interface'] + "." + kwargs['member'])
+    print("recipient: Caught signal (in catchall handler) "
+           + kwargs['dbus_interface'] + "->" + kwargs['member'])
     for arg in args:
-        print "        " + str(arg)
+        print("        " + str(arg))
 
 def catchall_hello_signals_handler(hello_string):
-    print "Received a hello signal and it says " + hello_string
-    
+    print("recipient: Received a hello signal and it says " + hello_string)
+
 def catchall_testservice_interface_handler(hello_string, dbus_message):
-    print "com.example.TestService interface says " + hello_string + " when it sent signal " + dbus_message.get_member()
+    print("recipient: com.example.TestService interface says " + hello_string + " when it sent signal " + dbus_message.get_member())
 
 
 if __name__ == '__main__':
@@ -79,10 +83,10 @@ if __name__ == '__main__':
     try:
         object  = bus.get_object("com.example.TestService","/com/example/TestService/object")
 
-        object.connect_to_signal("HelloSignal", hello_signal_handler, dbus_interface="com.example.TestService", arg0="Hello")
+        object.connect_to_signal("HelloSignal", hello_signal_handler, dbus_interface="com.example.TestService", arg0="HelloWorld")
     except dbus.DBusException:
         traceback.print_exc()
-        print usage
+        print(usage)
         sys.exit(1)
 
     #lets make a catchall
@@ -93,7 +97,7 @@ if __name__ == '__main__':
     bus.add_signal_receiver(catchall_testservice_interface_handler, dbus_interface = "com.example.TestService", message_keyword='dbus_message')
 
     # Tell the remote object to emit the signal after a short delay
-    gobject.timeout_add(2000, emit_signal)
+    GLib.timeout_add(2000, emit_signal)
 
-    loop = gobject.MainLoop()
+    loop = GLib.MainLoop()
     loop.run()


### PR DESCRIPTION
- Its helpful to distinguish between different types of clients/servers on the console while they are running at the same time with the help of appropriate prefix process labels in every print statement. E.g. "async client:",  "recipient:" etc.
- Added a print statement to async client example to demonstrate its async nature by showing that we can make calls and receive replies whenever we want and other operations can continue.
- Some other minor tweaks which you can notice while reviewing
- Few syntax changes and usage instruction updates based on freedesktop.org code which I referred to